### PR TITLE
Minor patch to density data prep

### DIFF
--- a/src/cljplot/impl/line.clj
+++ b/src/cljplot/impl/line.clj
@@ -88,8 +88,8 @@
 (defmethod prepare-data :density [_ data {:keys [kernel-bandwidth margins] :as conf}]
   (let [dens-data (extract-first data)
         f (if kernel-bandwidth
-            (stats/kernel-density dens-data kernel-bandwidth)
-            (stats/kernel-density dens-data))
+            (stats/kernel-density :default dens-data kernel-bandwidth)
+            (stats/kernel-density :default dens-data))
         with-domain (assoc conf :domain (extend-domain-numerical (take 2 (stats/extent dens-data)) (or (:x margins) [0 0])))]
     [with-domain (prepare-data :function f with-domain)]))
 


### PR DESCRIPTION
Working through dissecting the examples, starting with the first example in cljplot/sketches/examples.clj.
The plot wouldn't render.

I went ahead and deconstructed everything, found out that the side plots were causing the problem; fastmath.stats was complaining about improper arities for an anonymous function somewhere....

I eventually tracked it down to the calls from cljplot.impl.line/prepare-data :density  implementation, where the calls to stats/kernel-density wanted an extra arg or otherwise (perhaps the arity has changed recently) were no longer working with the default (smile).  After plugging the the :default as the dispatch value explicitly, rendering works again.