### PR TITLE
Make config a public atom.

### DIFF
--- a/src/cljplot/build.clj
+++ b/src/cljplot/build.clj
@@ -1,6 +1,6 @@
 (ns cljplot.build
   (:require [cljplot.common :refer :all]
-            [cljplot.config :refer :all]
+            [cljplot.config :as cfg]
             [cljplot.axis :as axis]
             [cljplot.scale :as s]
             [cljplot.build :as b]
@@ -97,7 +97,7 @@
 
 (defn- add-series-info
   "Add series id and chart type to configuration"
-  [id [t d c]] [t d (-> (merge-configuration t (or c {}))
+  [id [t d c]] [t d (-> (cfg/merge-configuration t (or c {}))
                         (assoc :series-id id :chart-type t))])
 
 (defn- chart-process-data
@@ -207,7 +207,7 @@
   ([series side] (add-axes series side {}))
   ([series side config]
    (let [conf-name (keyword (str "axis-" (name side)))
-         config (merge-configuration conf-name config)
+         config (cfg/merge-configuration conf-name config)
          scale-id (position->scale-id side)]
      (reduce (fn [s [pos scale]]
                (let [size (axis/axis-size scale scale-id config)]
@@ -222,7 +222,7 @@
 (defn add-label
   ([series side label] (add-label series side label {}))
   ([series side label conf]
-   (let [conf (merge-configuration :label conf)
+   (let [conf (cfg/merge-configuration :label conf)
          data (prepare-data :label label conf)]
      (assoc-in series [:labels side] data))))
 

--- a/src/cljplot/config.clj
+++ b/src/cljplot/config.clj
@@ -58,168 +58,169 @@
 
 (def ^:private stroke-common {:color nil :size 1.0 :cap :butt})
 
-(def ^:private configuration (merge axes-config 
-                                    {:abline {:color (c/gray 175)}
-                                     :legend {:color :black
-                                              :font "Liberation Mono"
-                                              :font-size 12
-                                              :gap 5
-                                              :marker-size 25}
-                                     :label {:color :black
-                                             :font "Liberation Mono"
-                                             :font-size 12
-                                             :font-style :bold
-                                             :margin 8}
-                                     :density-2d {:palette (c/palette-presets :gnbu-9)
-                                                  :kernel :gaussian
-                                                  :kernel-params nil
-                                                  :logarithmic? true
-                                                  :blur-kernel-size 0.1
-                                                  :contours 10
-                                                  :fill? true}
-                                     :contour-2d {:palette [:black :white]
-                                                  :contours 10
-                                                  :fill? true}
-                                     :binned-heatmap {:grid :pointy-hex
-                                                      :alpha-factor 0.0
-                                                      :size 20
-                                                      :gradient (comp (c/gradient-presets :k2) #(- 1.0 %))}
-                                     :heatmap {:gradient (comp (c/gradient-presets :k2) #(- 1.0 %))
-                                               :annotate? false
-                                               :annotate-fmt str}
-                                     :complex {:colorspace :HSB
-                                               :permutation 0
-                                               :wrap-method :log2}
-                                     :scalar {:gradient (c/gradient [:black :white])
-                                              :wrap-method nil}
-                                     :field {:color (c/color (c/darken dblue) 50)
-                                             :points 200000
-                                             :generator :r2
-                                             :jitter 0.1
-                                             :wrap? true}
-                                     :vector {:color (c/set-alpha dblue 200)
-                                              :size 20
-                                              :grid :square
-                                              :scale 0.8}
-                                     :trace {:color (c/set-alpha dblue 30)
-                                             :step 0.01
-                                             :length 200
-                                             :points 10000
-                                             :generator :r2
-                                             :jitter 0.1}
-                                     :histogram {:color blue
-                                                 :palette (cycle (c/palette-presets :category20))
-                                                 :stroke stroke-common
-                                                 :percents? true
-                                                 :stroke? true
-                                                 :type :bars
-                                                 :padding-in 0.1
-                                                 :padding-out 0.2
-                                                 :bins nil
-                                                 :margins {:x [0.05 0.05] :y [0.0 0.01]}}
-                                     :grid {:x {:color (c/color :gray 180)
-                                                :stroke {:size 0.5 :cap :butt :dash [4.0] :dash-phase 2.0}}
-                                            :y {:color (c/color :gray 180)
-                                                :stroke {:size 0.5 :cap :butt :dash [4.0] :dash-phase 2.0}}}
-                                     :rug {:color (c/set-alpha blue 100)
-                                           :size 1.0
-                                           :cap :butt
-                                           :scale 1.0
-                                           :distort 0.0
-                                           :margins {:x [0.05 0.05]}}
-                                     :strip {:color (c/set-alpha blue 50)
-                                             :size 10.0
-                                             :distort 0.0
-                                             :scale 1.0
-                                             :shape \O
-                                             :margins {:x [0.05 0.05]}}
-                                     :extent-stat {:extent-type :min-max
-                                                   :color blue
-                                                   :shape \A
-                                                   :size 10.0
-                                                   :stroke {:size 3.0 :cap :butt}
-                                                   :margins {:x [0.05 0.05]}}
-                                     :box {:color blue
-                                           :shape \O
-                                           :outliers? true
-                                           :size 1.0
-                                           :margins {:x [0.05 0.05]}}
-                                     :violin {:color blue
-                                              :color-bar (c/darken dblue)
-                                              :size-bar 5.0
-                                              :size 1.0
-                                              :normalize? true
-                                              :scale 0.85
-                                              :margins {:x [0.05 0.05]}
-                                              :kernel-bandwidth nil}
-                                     :density-strip {:color blue
-                                                     :size 1.0
-                                                     :normalize? true
-                                                     :kernel-bandwidth nil
-                                                     :scale 0.9
-                                                     :fill? false}
-                                     :scatter {:color (c/set-alpha blue 180)
-                                               :shape \O
-                                               :stroke {:size 1.0}
-                                               :size 4.0
-                                               :margins {:x [0.05 0.05] :y [0.05 0.05]}}
-                                     :bubble {:color (c/set-alpha blue 180)
-                                              :shape \O
-                                              :stroke {:size 1.0}
-                                              :size-range [2.0 10]
-                                              :scale-z [:pow 0.5]
-                                              :margins {:x [0.05 0.05] :y [0.05 0.05]}}
-                                     :gbubble {:color (c/set-alpha blue 180)
-                                               :shape \O
-                                               :stroke {:size 1.0}
-                                               :size-range [2.0 10]
-                                               :scale-z [:pow 0.5]
-                                               :cells 10
-                                               :grid-type :square
-                                               :margins {:x [0.05 0.05] :y [0.05 0.05]}}
-                                     :line {:color blue
-                                            :stroke {:size 1.0}
-                                            :interpolation nil
-                                            :smooth? false
-                                            :margins {:x [0.05 0.05] :y [0.05 0.05]}
-                                            :point {:type nil :size 6}}
-                                     :sarea {:palette (cycle (c/palette-presets :category20b))}
-                                     :function {:domain [0 1]
-                                                :samples nil
-                                                :color blue
-                                                :stroke {:size 1.0}
-                                                :interpolation nil
-                                                :margins {:x [0.05 0.05] :y [0.05 0.05]}
-                                                :smooth? false}
-                                     :density {:domain [0 1]
-                                               :samples nil
-                                               :color blue
-                                               :stroke {:size 1.0}
-                                               :interpolation nil
-                                               :smooth? false
-                                               :kernel-bandwidth nil
-                                               :margins {:x [0.1 0.1] :y [0.0 0.05]}
-                                               :area? false}
-                                     :bar {:color (fn [v _] (if (neg? v) red blue))
-                                           :stroke? true
-                                           :stroke {:color (fn [v _] (if (neg? v) dred dblue))
-                                                    :size 1.0}
-                                           :padding-in 0.1
-                                           :padding-out 0.2
-                                           :margin 0.0
-                                           :palette (c/palette-presets :category20)}
-                                     :rbar {:color blue
-                                            :stroke? true
-                                            :stroke {:size 1.0}
-                                            :padding 0.1}
-                                     :sbar {:stroke? true
-                                            :stroke {:size 1.0}
-                                            :padding 0.1
-                                            :margin 0.0
-                                            :method :stacked
-                                            :palette (c/palette-presets :category20)}
-                                     :stack {:padding-in 0.0
-                                             :padding-out 0.0}}))
+(def configuration (atom
+                    (merge axes-config 
+                           {:abline {:color (c/gray 175)}
+                            :legend {:color :black
+                                     :font "Liberation Mono"
+                                     :font-size 12
+                                     :gap 5
+                                     :marker-size 25}
+                            :label {:color :black
+                                    :font "Liberation Mono"
+                                    :font-size 12
+                                    :font-style :bold
+                                    :margin 8}
+                            :density-2d {:palette (c/palette-presets :gnbu-9)
+                                         :kernel :gaussian
+                                         :kernel-params nil
+                                         :logarithmic? true
+                                         :blur-kernel-size 0.1
+                                         :contours 10
+                                         :fill? true}
+                            :contour-2d {:palette [:black :white]
+                                         :contours 10
+                                         :fill? true}
+                            :binned-heatmap {:grid :pointy-hex
+                                             :alpha-factor 0.0
+                                             :size 20
+                                             :gradient (comp (c/gradient-presets :k2) #(- 1.0 %))}
+                            :heatmap {:gradient (comp (c/gradient-presets :k2) #(- 1.0 %))
+                                      :annotate? false
+                                      :annotate-fmt str}
+                            :complex {:colorspace :HSB
+                                      :permutation 0
+                                      :wrap-method :log2}
+                            :scalar {:gradient (c/gradient [:black :white])
+                                     :wrap-method nil}
+                            :field {:color (c/color (c/darken dblue) 50)
+                                    :points 200000
+                                    :generator :r2
+                                    :jitter 0.1
+                                    :wrap? true}
+                            :vector {:color (c/set-alpha dblue 200)
+                                     :size 20
+                                     :grid :square
+                                     :scale 0.8}
+                            :trace {:color (c/set-alpha dblue 30)
+                                    :step 0.01
+                                    :length 200
+                                    :points 10000
+                                    :generator :r2
+                                    :jitter 0.1}
+                            :histogram {:color blue
+                                        :palette (cycle (c/palette-presets :category20))
+                                        :stroke stroke-common
+                                        :percents? true
+                                        :stroke? true
+                                        :type :bars
+                                        :padding-in 0.1
+                                        :padding-out 0.2
+                                        :bins nil
+                                        :margins {:x [0.05 0.05] :y [0.0 0.01]}}
+                            :grid {:x {:color (c/color :gray 180)
+                                       :stroke {:size 0.5 :cap :butt :dash [4.0] :dash-phase 2.0}}
+                                   :y {:color (c/color :gray 180)
+                                       :stroke {:size 0.5 :cap :butt :dash [4.0] :dash-phase 2.0}}}
+                            :rug {:color (c/set-alpha blue 100)
+                                  :size 1.0
+                                  :cap :butt
+                                  :scale 1.0
+                                  :distort 0.0
+                                  :margins {:x [0.05 0.05]}}
+                            :strip {:color (c/set-alpha blue 50)
+                                    :size 10.0
+                                    :distort 0.0
+                                    :scale 1.0
+                                    :shape \O
+                                    :margins {:x [0.05 0.05]}}
+                            :extent-stat {:extent-type :min-max
+                                          :color blue
+                                          :shape \A
+                                          :size 10.0
+                                          :stroke {:size 3.0 :cap :butt}
+                                          :margins {:x [0.05 0.05]}}
+                            :box {:color blue
+                                  :shape \O
+                                  :outliers? true
+                                  :size 1.0
+                                  :margins {:x [0.05 0.05]}}
+                            :violin {:color blue
+                                     :color-bar (c/darken dblue)
+                                     :size-bar 5.0
+                                     :size 1.0
+                                     :normalize? true
+                                     :scale 0.85
+                                     :margins {:x [0.05 0.05]}
+                                     :kernel-bandwidth nil}
+                            :density-strip {:color blue
+                                            :size 1.0
+                                            :normalize? true
+                                            :kernel-bandwidth nil
+                                            :scale 0.9
+                                            :fill? false}
+                            :scatter {:color (c/set-alpha blue 180)
+                                      :shape \O
+                                      :stroke {:size 1.0}
+                                      :size 4.0
+                                      :margins {:x [0.05 0.05] :y [0.05 0.05]}}
+                            :bubble {:color (c/set-alpha blue 180)
+                                     :shape \O
+                                     :stroke {:size 1.0}
+                                     :size-range [2.0 10]
+                                     :scale-z [:pow 0.5]
+                                     :margins {:x [0.05 0.05] :y [0.05 0.05]}}
+                            :gbubble {:color (c/set-alpha blue 180)
+                                      :shape \O
+                                      :stroke {:size 1.0}
+                                      :size-range [2.0 10]
+                                      :scale-z [:pow 0.5]
+                                      :cells 10
+                                      :grid-type :square
+                                      :margins {:x [0.05 0.05] :y [0.05 0.05]}}
+                            :line {:color blue
+                                   :stroke {:size 1.0}
+                                   :interpolation nil
+                                   :smooth? false
+                                   :margins {:x [0.05 0.05] :y [0.05 0.05]}
+                                   :point {:type nil :size 6}}
+                            :sarea {:palette (cycle (c/palette-presets :category20b))}
+                            :function {:domain [0 1]
+                                       :samples nil
+                                       :color blue
+                                       :stroke {:size 1.0}
+                                       :interpolation nil
+                                       :margins {:x [0.05 0.05] :y [0.05 0.05]}
+                                       :smooth? false}
+                            :density {:domain [0 1]
+                                      :samples nil
+                                      :color blue
+                                      :stroke {:size 1.0}
+                                      :interpolation nil
+                                      :smooth? false
+                                      :kernel-bandwidth nil
+                                      :margins {:x [0.1 0.1] :y [0.0 0.05]}
+                                      :area? false}
+                            :bar {:color (fn [v _] (if (neg? v) red blue))
+                                  :stroke? true
+                                  :stroke {:color (fn [v _] (if (neg? v) dred dblue))
+                                           :size 1.0}
+                                  :padding-in 0.1
+                                  :padding-out 0.2
+                                  :margin 0.0
+                                  :palette (c/palette-presets :category20)}
+                            :rbar {:color blue
+                                   :stroke? true
+                                   :stroke {:size 1.0}
+                                   :padding 0.1}
+                            :sbar {:stroke? true
+                                   :stroke {:size 1.0}
+                                   :padding 0.1
+                                   :margin 0.0
+                                   :method :stacked
+                                   :palette (c/palette-presets :category20)}
+                            :stack {:padding-in 0.0
+                                    :padding-out 0.0}})))
 
 (def aliases {:lag :scatter
               :acf :scatter
@@ -255,13 +256,12 @@
                (assoc %1 %2 (val->fn (get %1 %2)))) m keys)))
 
 (defn merge-configuration
-  "Merge two configs and convert selected values to keys." 
+  "Merge two configs and convert selected values to keys."
   [chart-type config]
   (if-let [alias (aliases chart-type)]
     (merge-configuration alias config)
-    (apply coerce-fn (deep-merge (configuration chart-type) config) (configuration-functions chart-type))))
+    (apply coerce-fn (deep-merge (@configuration chart-type) config) (configuration-functions chart-type))))
 
 (defn get-configuration
   [chart-type]
   (merge-configuration chart-type {}))
-

--- a/src/cljplot/impl/strips.clj
+++ b/src/cljplot/impl/strips.clj
@@ -1,6 +1,6 @@
 (ns cljplot.impl.strips
   (:require [cljplot.common :refer :all]
-            [cljplot.config :refer :all]
+            [cljplot.config :as cfg]
             [fastmath.random :as r]
             [clojure2d.core :refer :all]
             [fastmath.stats :as stats]
@@ -328,7 +328,7 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 (defmethod prepare-data :stack [_ [h? t data c] _]
-  (let [c (merge-configuration t (or c {}))]
+  (let [c (cfg/merge-configuration t (or c {}))]
     [h? t (map-indexed (fn [iter [k v]]
                          (let [cc (assoc c :id k :series-id iter :chart-type t)
                                dd (prepare-data t v cc)


### PR DESCRIPTION
Not really a long term solution, but does make things like the legend
font and sizes configurable now.

The other option for me at the moment is to run my own locally customised version, which I'd prefer to avoid if possible.